### PR TITLE
Add E2E tests for login redirect flow and rename middleware

### DIFF
--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -74,4 +74,76 @@ test.describe('Authentication', () => {
     await page.waitForURL('**/addSongs', { timeout: 10000 });
     await expect(page).toHaveURL(/.*addSongs/);
   });
+
+  test('should redirect to login and back to addSongs when clicking Add Song button while unauthenticated', async ({ page }) => {
+    // 1. Go to homepage
+    await page.goto('/');
+
+    // 2. Click the "Add Song" button
+    const addSongButton = page.locator('button:has-text("Add Song")');
+    await expect(addSongButton).toBeVisible();
+    await addSongButton.click();
+
+    // 3. Expect to be on login page with correct query param
+    await page.waitForURL(/.*login\?redirectTo=%2FaddSongs/);
+    await expect(page).toHaveURL(/.*login\?redirectTo=%2FaddSongs/);
+
+    // 4. Fill password and authenticate
+    await page.fill('input[name="answer"]', process.env.PASSWORD || 'HeartOfWorship');
+    await page.click('button:has-text("Authenticate")');
+
+    // 5. Should end up on the /addSongs page
+    await page.waitForURL('**/addSongs', { timeout: 10000 });
+    await expect(page).toHaveURL(/.*addSongs/);
+    await expect(page.locator('h1:has-text("Add Songs")')).toBeVisible();
+  });
+
+  test('should redirect to login and back to editSong when clicking Edit Song button while unauthenticated', async ({ page, context }) => {
+    // 1. Log in first to add a test song
+    await page.goto('/login');
+    await page.fill('input[name="answer"]', process.env.PASSWORD || 'HeartOfWorship');
+    await page.click('button:has-text("Authenticate")');
+    await page.waitForURL('**/addSongs');
+
+    // 2. Add a new song
+    await page.click('button:has-text("Add Song")');
+    const rand = Math.random().toString(36).substring(7);
+    const originalTitle = `RedirectUIEditTitle${rand}`;
+    const originalLyrics = `RedirectUIEditLyrics${rand}`;
+    
+    await page.fill('input[placeholder="Title"]', originalTitle);
+    await page.fill('textarea[placeholder="Lyrics"]', originalLyrics);
+    await page.click('button:has-text("Add Song")');
+    await page.waitForURL('http://localhost:3001/');
+
+    // 3. Clear cookies to become unauthenticated
+    await context.clearCookies();
+
+    // 4. Go back to homepage unauthenticated
+    await page.goto('/');
+
+    // 5. Find and click the newly added song to view it
+    const songButton = page.locator(`button:has-text("${originalTitle}")`);
+    await expect(songButton).toBeVisible();
+    await songButton.click();
+
+    // 6. Click the Edit button
+    const editButton = page.locator('button[title="Edit Song"]');
+    await expect(editButton).toBeVisible();
+    await editButton.click();
+
+    // 7. Verify we are redirected to login with the correct redirectTo parameter
+    await page.waitForURL(/.*login\?redirectTo=.*/);
+    expect(page.url()).toContain('redirectTo=%2FeditSong%3FsongId%3D');
+
+    // 8. Log in again
+    await page.fill('input[name="answer"]', process.env.PASSWORD || 'HeartOfWorship');
+    await page.click('button:has-text("Authenticate")');
+
+    // 9. Verify we land on the Edit page for that song
+    await page.waitForURL(/.*editSong.*/, { timeout: 10000 });
+    await expect(page).toHaveURL(/.*editSong\?songId=.*/);
+    const titleInput = page.locator('input[placeholder="Title"]');
+    await expect(titleInput).toHaveValue(originalTitle);
+  });
 });

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,7 +5,7 @@ import { decrypt } from "@/lib/session";
 const protectedRoutes = ["/addSongs", "/editSong"];
 // const publicRoutes = ["/login", "/"];
 
-export default async function middleware(req: NextRequest) {
+export default async function proxy(req: NextRequest) {
   // 2. Check if the current route is protected or public
   const path = req.nextUrl.pathname;
   const isProtectedRoute = protectedRoutes.includes(path);


### PR DESCRIPTION
Added test cases to verify that unauthenticated users are redirected to the login page and back to their intended destination (Add Song or Edit Song) after successful authentication. Also renamed middleware.ts to proxy.ts.